### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,7 @@ Build-Depends: debhelper-compat (= 12),
                libukui-log4qt-dev
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
-Homepage: http://www.ukui.org/
+Homepage: https://www.ukui.org/
 Vcs-Git: https://github.com/ukui/ukui-media.git
 Vcs-Browser: https://github.com/ukui/ukui-media
 

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Kylin Team <team+kylin@tracker.debian.org>
 Uploaders: Aron Xu <aron@debian.org>,
            handsome_feng <jianfengli@ubuntukylin.com>,
-Build-Depends: debhelper-compat (= 12),
+Build-Depends: debhelper-compat (= 13),
                dpkg-dev (>= 1.16.1.1),
                intltool,
                qtbase5-dev,

--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Build-Depends: debhelper-compat (= 13),
                libasound2-dev,
                libpulse-dev,
                libukui-log4qt-dev
-Standards-Version: 4.6.1
+Standards-Version: 4.6.2
 Rules-Requires-Root: no
 Homepage: https://www.ukui.org/
 Vcs-Git: https://github.com/ukui/ukui-media.git

--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Build-Depends: debhelper-compat (= 13),
                libasound2-dev,
                libpulse-dev,
                libukui-log4qt-dev
-Standards-Version: 4.5.0
+Standards-Version: 4.6.1
 Rules-Requires-Root: no
 Homepage: https://www.ukui.org/
 Vcs-Git: https://github.com/ukui/ukui-media.git

--- a/debian/rules
+++ b/debian/rules
@@ -13,9 +13,6 @@ include /usr/share/dpkg/buildflags.mk
 #	make install INSTALL_ROOT=$(QT_INSTALL_DIR) -C ukui-volume-control/ukui-volume-control-applet-qt/build/
 #	dh_install
 
-override_dh_missing:
-	dh_missing --fail-missing
-
 override_dh_auto_configure:
 	# upstream tarball is without configure. autogen.sh will create it
 	NOCONFIGURE=1 ./autogen.sh

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/ukui/ukui-media/issues
+Bug-Submit: https://github.com/ukui/ukui-media/issues/new
+Repository: https://github.com/ukui/ukui-media.git
+Repository-Browse: https://github.com/ukui/ukui-media


### PR DESCRIPTION
Fix some issues reported by lintian

* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri))
* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))
* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

## Debdiff

These changes affect the binary packages:

[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/2d/db91930a86140393195393cfcbc2406d44f862.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/6e/588af250e54c2ada49f0aac8b66f1f5b882beb.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/6f/292ec2a46caba04fd945f7df4e6eacdce3586b.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/b8/f68a305927f1096029c1ea72769c6a1c1ce39c.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/42/5d6a121ed030528940ed3b0607251b8e7f25f5.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/83/4b57ab88e446c145cb8abcda6e9f33bdf23c8e.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/bf/d19f640e3399e483fef4eaf27f20c647269246.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/fd/1d64c42cdf8b5faf8e36762512e9668f77c0f2.debug
### Control files of package ukui-media: lines which differ (wdiff format)
* Depends: mate-desktop-common (>= 1.18), ukui-media-common (=  dconf-gsettings-backend | gsettings-backend, libasound2 (>= 1.0.24.1), libc6 (>= [-2.14),-] {+2.34),+} libcairo2 (>= 1.2.4), libcanberra-gtk3-0 (>= 0.25), libcanberra0 (>= 0.2), libdconf1 (>= 0.14.0), libgcc-s1 (>= 3.0), libglib2.0-0 (>= 2.37.3), libgsettings-qt1 (>= 0.1+14.04.20140408), libgtk-3-0 (>= 3.21.4), libkf5windowsystem5 (>= 4.96.0), libmate-desktop-2-17 (>= 1.18), libmatemixer0 (>= 1.18), libpango-1.0-0 (>= 1.14.0), libpulse-mainloop-glib0 (>= 0.99.1), libpulse0 (>= 0.99.1), libqt5core5a (>= 5.15.1), libqt5dbus5 (>= 5.14.1), libqt5gui5 (>= 5.14.1) | libqt5gui5-gles (>= 5.14.1), libqt5multimedia5 (>= 5.6.0~beta), libqt5network5 (>= 5.0.2), libqt5widgets5 (>= 5.15.1), libqt5xml5 (>= 5.0.2), libstdc++6 (>= 11), libukui-log4qt1 (>= 1.0.1), libx11-6, libxml2 (>= 2.7.4), libglib2.0-bin
* Homepage: [-http&#8203;://www.ukui.org/-] {+https&#8203;://www.ukui.org/+}
### Control files of package ukui-media-common: lines which differ (wdiff format)
* Homepage: [-http&#8203;://www.ukui.org/-] {+https&#8203;://www.ukui.org/+}
### Control files of package ukui-media-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-425d6a121ed030528940ed3b0607251b8e7f25f5 834b57ab88e446c145cb8abcda6e9f33bdf23c8e bfd19f640e3399e483fef4eaf27f20c647269246 fd1d64c42cdf8b5faf8e36762512e9668f77c0f2-] {+2ddb91930a86140393195393cfcbc2406d44f862 6e588af250e54c2ada49f0aac8b66f1f5b882beb 6f292ec2a46caba04fd945f7df4e6eacdce3586b b8f68a305927f1096029c1ea72769c6a1c1ce39c+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/4cb430d6-8cbc-4c68-b664-0436914a28ef/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/4cb430d6-8cbc-4c68-b664-0436914a28ef/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/run/4cb430d6-8cbc-4c68-b664-0436914a28ef.